### PR TITLE
Update _layouts/default.html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
 		<div id="main">
       <div class="ribbon"> 
         <a href="https://github.com/kaaes/work_from_cafe">
-          <img src="https://assets1.github.com/img/e6bef7a091f5f3138b8cd40bc3e114258dd68ddf?repo=&amp;url=http%3A%2F%2Fs3.amazonaws.com%2Fgithub%2Fribbons%2Fforkme_right_red_aa0000.png&amp;path://d3nwyuy0nl342s.cloudfront.net/img/c641758e06304bc53ae7f633269018169e7e5851/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f77686974655f6666666666662e706e6://d3nwyuy0nl342s.cloudfront.net/img/71eeaab9d563c2b3c590319b398dd35683265e85/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e6" alt="Fork me on GitHub">
+          <img src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub">
         </a> 
       </div>
 			<div id="content" class="site">


### PR DESCRIPTION
Bugfix: the ribbon has now a working src.

The ribbon image did not have a working src. I thus changed it for a red ribbon one. Feel free to refuse the pull request and select one you like from https://github.com/blog/273-github-ribbons
